### PR TITLE
Make PyDC work properly under Python 3

### DIFF
--- a/PyDC/PyDC/CassetteObjects.py
+++ b/PyDC/PyDC/CassetteObjects.py
@@ -656,7 +656,7 @@ class Cassette:
 
         def _write(f, codepoint):
             try:
-                f.write(chr(codepoint))
+                f.write(bytes([codepoint]))
             except ValueError as err:
                 log.error(f"Value error with {repr(codepoint)}: {err}")
                 raise

--- a/PyDC/PyDC/base_cli.py
+++ b/PyDC/PyDC/base_cli.py
@@ -39,8 +39,6 @@ class Base_CLI:
             arg_kwargs["description"] = self.DESCRIPTION
         if self.EPOLOG is not None:
             arg_kwargs["epilog"] = self.EPOLOG
-        if self.VERSION is not None:
-            arg_kwargs["version"] = self.VERSION
 
         self.parser = argparse.ArgumentParser(**arg_kwargs)
 

--- a/PyDC/PyDC/bitstream_handler.py
+++ b/PyDC/PyDC/bitstream_handler.py
@@ -259,17 +259,12 @@ class CasStream:
         self.pos = 0
         self.file_generator = self.__file_generator()
 
-        self.yield_ord = True
-
     def __iter__(self):
         return self
 
     def __next__(self):
         byte = next(self.file_generator)
-        if self.yield_ord:
-            return ord(byte)
-        else:
-            return byte
+        return byte
 
     def __file_generator(self):
         max = self.file_size + 1

--- a/PyDC/PyDC/wave2bitstream.py
+++ b/PyDC/PyDC/wave2bitstream.py
@@ -11,6 +11,7 @@ import itertools
 import logging
 import math
 import struct
+import sys
 import time
 import wave
 
@@ -158,7 +159,7 @@ class Wave2Bitstream(WaveBase):
         percent = float(self.wave_pos) / self.frame_count * 100
         rest, eta, rate = process_info.update(self.wave_pos)
         sys.stdout.write(
-            f"\r{percent:.1f}% wav pos:{self.pformat_pos()} - eta: {eta} (rate: {rate:d}Frames/sec)       ")
+            f"\r{percent:.1f}% wav pos:{self.pformat_pos()} - eta: {eta} (rate: {int(rate)}Frames/sec)       ")
         sys.stdout.flush()
 
     def _get_statistics(self, max=None):


### PR DESCRIPTION
This at least allows the tool to convert between .cas, .wav, and .bas without erroring out. Have not been able to verify the .wav conversions are correct with known-good files.